### PR TITLE
Extract backend into the DataModule and Generalize control functionality

### DIFF
--- a/ProjectMineMagicClient.dproj
+++ b/ProjectMineMagicClient.dproj
@@ -211,15 +211,15 @@
         <DCCReference Include="UnitVoiceRecorder.pas"/>
         <DCCReference Include="UnitCommander.pas"/>
         <DCCReference Include="UnitSpeechRecognizer.pas"/>
-        <BuildConfiguration Include="Release">
-            <Key>Cfg_2</Key>
-            <CfgParent>Base</CfgParent>
-        </BuildConfiguration>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
@@ -239,93 +239,9 @@
                 </Excluded_Packages>
             </Delphi.Personality>
             <Deployment Version="3">
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_SplashImage_960x720.png" Configuration="Debug" Class="Android_SplashImage960">
-                    <Platform Name="Android64">
-                        <RemoteName>splash_image.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_96x96.png" Configuration="Debug" Class="Android_LauncherIcon96">
-                    <Platform Name="Android64">
-                        <RemoteName>ic_launcher.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_72x72.png" Configuration="Debug" Class="Android_LauncherIcon72">
-                    <Platform Name="Android64">
-                        <RemoteName>ic_launcher.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_NotificationIcon_48x48.png" Configuration="Debug" Class="Android_NotificationIcon48">
-                    <Platform Name="Android64">
-                        <RemoteName>ic_notification.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_NotificationIcon_96x96.png" Configuration="Debug" Class="Android_NotificationIcon96">
-                    <Platform Name="Android64">
-                        <RemoteName>ic_notification.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_SplashImage_640x480.png" Configuration="Debug" Class="Android_SplashImage640">
-                    <Platform Name="Android64">
-                        <RemoteName>splash_image.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_NotificationIcon_72x72.png" Configuration="Debug" Class="Android_NotificationIcon72">
-                    <Platform Name="Android64">
-                        <RemoteName>ic_notification.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
                 <DeployFile LocalName="$(BDS)\lib\android\debug\armeabi-v7a\libnative-activity.so" Configuration="Debug" Class="AndroidLibnativeArmeabiv7aFile">
                     <Platform Name="Android64">
                         <RemoteName>libProjectMineMagic.so</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_SplashImage_470x320.png" Configuration="Debug" Class="Android_SplashImage470">
-                    <Platform Name="Android64">
-                        <RemoteName>splash_image.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\lib\android\debug\mips\libnative-activity.so" Configuration="Debug" Class="AndroidLibnativeMipsFile">
-                    <Platform Name="Android64">
-                        <RemoteName>libProjectMineMagic.so</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\lib\android\debug\armeabi\libnative-activity.so" Configuration="Debug" Class="AndroidLibnativeArmeabiFile">
-                    <Platform Name="Android64">
-                        <RemoteName>libProjectMineMagic.so</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_36x36.png" Configuration="Debug" Class="Android_LauncherIcon36">
-                    <Platform Name="Android64">
-                        <RemoteName>ic_launcher.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_144x144.png" Configuration="Debug" Class="Android_LauncherIcon144">
-                    <Platform Name="Android64">
-                        <RemoteName>ic_launcher.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="Win64\Debug\ProjectMineMagicClient.rsm" Configuration="Debug" Class="DebugSymbols">
-                    <Platform Name="Win64">
-                        <RemoteName>ProjectMineMagicClient.rsm</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="Android64\Debug\libProjectMineMagicClient.so" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Android64">
-                        <RemoteName>libProjectMineMagicClient.so</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -335,13 +251,27 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Android64\Debug\styles.xml" Configuration="Debug" Class="AndroidSplashStyles">
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_72x72.png" Configuration="Debug" Class="Android_LauncherIcon72">
                     <Platform Name="Android64">
+                        <RemoteName>ic_launcher.png</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Android64\Debug\colors.xml" Configuration="Debug" Class="Android_Colors">
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_SplashImage_960x720.png" Configuration="Debug" Class="Android_SplashImage960">
                     <Platform Name="Android64">
+                        <RemoteName>splash_image.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_36x36.png" Configuration="Debug" Class="Android_LauncherIcon36">
+                    <Platform Name="Android64">
+                        <RemoteName>ic_launcher.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Android64\Debug\libProjectMineMagicClient.so" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Android64">
+                        <RemoteName>libProjectMineMagicClient.so</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -350,7 +280,35 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_NotificationIcon_36x36.png" Configuration="Debug" Class="Android_NotificationIcon36">
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_144x144.png" Configuration="Debug" Class="Android_LauncherIcon144">
+                    <Platform Name="Android64">
+                        <RemoteName>ic_launcher.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png" Configuration="Debug" Class="Android_LauncherIcon48">
+                    <Platform Name="Android64">
+                        <RemoteName>ic_launcher.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_192x192.png" Configuration="Debug" Class="Android_LauncherIcon192">
+                    <Platform Name="Android64">
+                        <RemoteName>ic_launcher.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="OSX32">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Android64\Debug\styles.xml" Configuration="Debug" Class="AndroidSplashStyles">
+                    <Platform Name="Android64">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_NotificationIcon_48x48.png" Configuration="Debug" Class="Android_NotificationIcon48">
                     <Platform Name="Android64">
                         <RemoteName>ic_notification.png</RemoteName>
                         <Overwrite>true</Overwrite>
@@ -362,47 +320,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Android64\Debug\splash_image_def.xml" Configuration="Debug" Class="AndroidSplashImageDef">
-                    <Platform Name="Android64">
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png" Configuration="Debug" Class="Android_LauncherIcon48">
-                    <Platform Name="Android64">
-                        <RemoteName>ic_launcher.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
                 <DeployFile LocalName="Win32\Debug\ProjectMineMagicClient.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>ProjectMineMagicClient.exe</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libpcre.dylib" Class="DependencyModule">
-                    <Platform Name="iOSSimulator">
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">
-                    <Platform Name="iOSSimulator">
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_192x192.png" Configuration="Debug" Class="Android_LauncherIcon192">
-                    <Platform Name="Android64">
-                        <RemoteName>ic_launcher.png</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="Win64\Debug\ProjectMineMagicClient.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win64">
-                        <RemoteName>ProjectMineMagicClient.exe</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib" Class="DependencyModule">
-                    <Platform Name="OSX32">
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -412,14 +332,94 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_SplashImage_640x480.png" Configuration="Debug" Class="Android_SplashImage640">
+                    <Platform Name="Android64">
+                        <RemoteName>splash_image.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\lib\android\debug\armeabi\libnative-activity.so" Configuration="Debug" Class="AndroidLibnativeArmeabiFile">
+                    <Platform Name="Android64">
+                        <RemoteName>libProjectMineMagic.so</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Win64\Debug\ProjectMineMagicClient.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win64">
+                        <RemoteName>ProjectMineMagicClient.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libpcre.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Android64\Debug\strings.xml" Configuration="Debug" Class="Android_Strings">
+                    <Platform Name="Android64">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
                 <DeployFile LocalName="Android64\Debug\styles-v21.xml" Configuration="Debug" Class="AndroidSplashStylesV21">
                     <Platform Name="Android64">
                         <RemoteName>styles.xml</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Android64\Debug\strings.xml" Configuration="Debug" Class="Android_Strings">
+                <DeployFile LocalName="Android64\Debug\colors.xml" Configuration="Debug" Class="Android_Colors">
                     <Platform Name="Android64">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_NotificationIcon_96x96.png" Configuration="Debug" Class="Android_NotificationIcon96">
+                    <Platform Name="Android64">
+                        <RemoteName>ic_notification.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_NotificationIcon_72x72.png" Configuration="Debug" Class="Android_NotificationIcon72">
+                    <Platform Name="Android64">
+                        <RemoteName>ic_notification.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_NotificationIcon_36x36.png" Configuration="Debug" Class="Android_NotificationIcon36">
+                    <Platform Name="Android64">
+                        <RemoteName>ic_notification.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Android64\Debug\splash_image_def.xml" Configuration="Debug" Class="AndroidSplashImageDef">
+                    <Platform Name="Android64">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">
+                    <Platform Name="iOSSimulator">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\lib\android\debug\mips\libnative-activity.so" Configuration="Debug" Class="AndroidLibnativeMipsFile">
+                    <Platform Name="Android64">
+                        <RemoteName>libProjectMineMagic.so</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_96x96.png" Configuration="Debug" Class="Android_LauncherIcon96">
+                    <Platform Name="Android64">
+                        <RemoteName>ic_launcher.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\bin\Artwork\Android\FM_SplashImage_470x320.png" Configuration="Debug" Class="Android_SplashImage470">
+                    <Platform Name="Android64">
+                        <RemoteName>splash_image.png</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Win64\Debug\ProjectMineMagicClient.rsm" Configuration="Debug" Class="DebugSymbols">
+                    <Platform Name="Win64">
+                        <RemoteName>ProjectMineMagicClient.rsm</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -746,6 +746,11 @@
                         <Operation>1</Operation>
                         <Extensions>.framework</Extensions>
                     </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.framework</Extensions>
+                    </Platform>
                     <Platform Name="Win32">
                         <Operation>0</Operation>
                     </Platform>
@@ -769,6 +774,11 @@
                         <Extensions>.dylib</Extensions>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
+                    <Platform Name="OSXARM64">
                         <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
@@ -801,6 +811,11 @@
                         <Operation>1</Operation>
                         <Extensions>.dylib</Extensions>
                     </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                        <Extensions>.dylib</Extensions>
+                    </Platform>
                     <Platform Name="Win32">
                         <Operation>0</Operation>
                         <Extensions>.bpl</Extensions>
@@ -827,6 +842,10 @@
                         <Operation>0</Operation>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>Contents\Resources\StartUp\</RemoteDir>
+                        <Operation>0</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
                         <RemoteDir>Contents\Resources\StartUp\</RemoteDir>
                         <Operation>0</Operation>
                     </Platform>
@@ -1095,6 +1114,10 @@
                         <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="ProjectOSXEntitlements">
                     <Platform Name="OSX32">
@@ -1102,6 +1125,10 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>..\</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
                         <RemoteDir>..\</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -1115,6 +1142,10 @@
                         <RemoteDir>Contents</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="OSXARM64">
+                        <RemoteDir>Contents</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="ProjectOSXResource">
                     <Platform Name="OSX32">
@@ -1122,6 +1153,10 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>Contents\Resources</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
                         <RemoteDir>Contents\Resources</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -1152,6 +1187,10 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="OSX64">
+                        <RemoteDir>Contents\MacOS</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="OSXARM64">
                         <RemoteDir>Contents\MacOS</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -1193,17 +1232,17 @@
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>
-                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
-                <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
-                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME).app"/>
-                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="OSX32" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="OSX64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="OSXARM64" Name="$(PROJECTNAME).app"/>
                 <ProjectRoot Platform="Android" Name="$(PROJECTNAME)"/>
-                <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Android64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="iOSDevice32" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="iOSDevice64" Name="$(PROJECTNAME).app"/>
+                <ProjectRoot Platform="Linux64" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
             </Deployment>
             <Platforms>
                 <Platform value="Android">True</Platform>

--- a/ProjectMineMagicServer.dpr
+++ b/ProjectMineMagicServer.dpr
@@ -5,13 +5,16 @@ uses
   UnitMain in 'UnitMain.pas' {FormMain},
   UnitCommander in 'UnitCommander.pas',
   UnitMineScripter in 'UnitMineScripter.pas',
-  UnitTelegrammer in 'UnitTelegrammer.pas';
+  UnitTelegrammer in 'UnitTelegrammer.pas',
+  UnitMineModule in 'UnitMineModule.pas' {MineModule: TDataModule};
 
 {$R *.res}
 
 begin
   Application.Initialize;
   Application.MainFormOnTaskbar := True;
+  Application.CreateForm(TMineModule, MineModule); //reordered creation!
   Application.CreateForm(TFormMain, FormMain);
+
   Application.Run;
 end.

--- a/ProjectMineMagicServer.dproj
+++ b/ProjectMineMagicServer.dproj
@@ -141,6 +141,11 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <DCCReference Include="UnitCommander.pas"/>
         <DCCReference Include="UnitMineScripter.pas"/>
         <DCCReference Include="UnitTelegrammer.pas"/>
+        <DCCReference Include="UnitMineModule.pas">
+            <Form>MineModule</Form>
+            <FormType>dfm</FormType>
+            <DesignClass>TDataModule</DesignClass>
+        </DCCReference>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -169,12 +174,6 @@ $(PostBuildEvent)]]></PostBuildEvent>
                 </Excluded_Packages>
             </Delphi.Personality>
             <Deployment Version="3">
-                <DeployFile LocalName="Win64\Debug\ProjectMineMagicServer.rsm" Configuration="Debug" Class="DebugSymbols">
-                    <Platform Name="Win64">
-                        <RemoteName>ProjectMineMagicServer.rsm</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
                 <DeployFile LocalName="Win32\Debug\ProjectMineMagicServer.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>ProjectMineMagicServer.exe</RemoteName>
@@ -184,6 +183,12 @@ $(PostBuildEvent)]]></PostBuildEvent>
                 <DeployFile LocalName="Win64\Debug\ProjectMineMagicServer.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win64">
                         <RemoteName>ProjectMineMagicServer.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="Win64\Debug\ProjectMineMagicServer.rsm" Configuration="Debug" Class="DebugSymbols">
+                    <Platform Name="Win64">
+                        <RemoteName>ProjectMineMagicServer.rsm</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -1031,7 +1036,7 @@ $(PostBuildEvent)]]></PostBuildEvent>
         <PreBuildEventIgnoreExitCode>False</PreBuildEventIgnoreExitCode>
         <PreLinkEvent/>
         <PreLinkEventIgnoreExitCode>False</PreLinkEventIgnoreExitCode>
-        <PostBuildEvent>xcopy.exe .\minecommander.ini $(OUTPUTDIR) /Y</PostBuildEvent>
+        <PostBuildEvent>xcopy.exe .\minecommander.ini $(OUTPUTDIR) /Y</PostBuildEvent>
         <PostBuildEventIgnoreExitCode>False</PostBuildEventIgnoreExitCode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Release' And '$(Platform)'=='Win32'">

--- a/UnitCommander.pas
+++ b/UnitCommander.pas
@@ -2,7 +2,7 @@ unit UnitCommander;
 
 interface
 
-uses UnitVoiceRecorder, UnitSpeechRecognizer, UnitTelegrammer,
+uses UnitVoiceRecorder, UnitSpeechRecognizer,
   System.Generics.Collections, System.SysUtils, System.Classes;
 type
   TRPCMineCommands = (rpcMagic, rpcStartRecord, rpcStopRecord, rpcRecognize);
@@ -48,7 +48,6 @@ type
   TMineCommander = Class
     Recorder: TVoiceRecorder;
     Recognizer: TSpeechRecognizer;
-    TgBot: TTelegramBot;
   private
     const MAGIC_KEY = 'MAGIC';
     RPC_MAGIC = 0;
@@ -73,7 +72,7 @@ type
     procedure PassCommand(CommandKey: String; Commandline: String = ''); overload;
     procedure PassCommand(Cmd: Integer; ArgData: String = ''); overload;
     procedure ReceiveCommand(Cmd: Integer; ArgData: TArray<System.Byte>);
-  private
+
     function RecognizeMineVoice(filename: String): String;
     function RecognizeMineCommand(sentence: String): String;
   private
@@ -106,11 +105,6 @@ type
     property InitScriptingProc: TProc write _InitScriptingProc;
   private
     procedure ConfigureAsServer;
-  private
-    function getTgBotActive(): Boolean;
-    procedure setTgBotActive(Active: Boolean);
-  public
-    property TgBotActive: Boolean read getTgBotActive write setTgBotActive;
   End;
 
 var MineCommander: TMineCommander;
@@ -166,23 +160,8 @@ begin
   UnitSpeechRecognizer.filenameini := 'minecommander.ini';
   Recognizer := TSpeechRecognizer.ObtainRecognizer(asrAzure);
 
-  UnitTelegrammer.filenameini := 'minecommander.ini';
-  TgBot := TTelegramBot.InstantinateBot();
-  TgBot.ProcessVoiceFile := (
-    procedure (voiceFileName: String; Reply: TProc<string>)
-    begin
-      var voice := RecognizeMineVoice(voiceFileName);
-      Reply('Accepted: ' + voice);
-        PassCommand('MAGIC', voice);
-    end
-  );
-  TgBot.ProcessTextMessage :=  (
-    procedure (text: String; Reply: TProc<string>)
-    begin
-      Reply('Accepted: ' + text);
-        PassCommand('MAGIC', text);
-    end
-  );
+
+
 
   _MagicCommands := TDictionary<String, TCommandRec>.Create();
   _WillList := TThreadList.Create();
@@ -223,10 +202,7 @@ begin
     RESULT := '';
 end;
 
-function TMineCommander.getTgBotActive: Boolean;
-begin
-  RESULT := Self.TgBot.Active;
-end;
+
 
 function TMineCommander.ListKeywords(Prefix: Char; delimiter: String; Postfix: Char): String;
 const STR_QOUTA = '"';
@@ -425,14 +401,7 @@ begin
 end;
 
 
-procedure TMineCommander.setTgBotActive(Active: Boolean);
-begin
-  if Active <> Self.TgBot.Active then
-    if Active then
-      Self.TgBot.Run()
-    else
-      Self.TgBot.Terminate();
-end;
+
 
 
 

--- a/UnitCommander.pas
+++ b/UnitCommander.pas
@@ -237,6 +237,8 @@ begin
     IniFile.ReadSectionValues('COMMANDS', CommandList);
     for var command in  Commands do
     begin
+      if command.StartsWith('#') then
+        CONTINUE;
       cmdRec.Keyword := command;
       cmdRec.InstatinationScript := CommandList.Values[command];
       _MagicCommands.Add(command, cmdRec);

--- a/UnitMain.dfm
+++ b/UnitMain.dfm
@@ -114,85 +114,6 @@ object FormMain: TFormMain
         Height = 15
         Caption = 'Loop Delay, ms '
       end
-      object ComboBoxBlocks: TComboBox
-        Left = 543
-        Top = 58
-        Width = 145
-        Height = 23
-        TabOrder = 0
-        Text = 'Select block...'
-        Items.Strings = (
-          'AIR                  '
-          'STONE                '
-          'GRASS                '
-          'DIRT                 '
-          'COBBLESTONE          '
-          'WOOD PLANKS          '
-          'SAPLING              '
-          'BEDROCK              '
-          'WATER FLOWING        '
-          'WATER STATIONARY     '
-          'LAVA FLOWING         '
-          'LAVA STATIONARY      '
-          'SAND                 '
-          'GRAVEL               '
-          'GOLD ORE             '
-          'IRON ORE             '
-          'COAL ORE             '
-          'WOOD                 '
-          'LEAVES               '
-          'GLASS                '
-          'LAPIS LAZULI ORE     '
-          'LAPIS LAZULI BLOCK   '
-          'SANDSTONE            '
-          'BED                  '
-          'COBWEB               '
-          'GRASS TALL           '
-          'WOOL                 '
-          'FLOWER YELLOW        '
-          'FLOWER CYAN          '
-          'MUSHROOM BROWN       '
-          'MUSHROOM RED         '
-          'GOLD BLOCK           '
-          'IRON BLOCK           '
-          'STONE SLAB DOUBLE    '
-          'STONE SLAB           '
-          'BRICK BLOCK          '
-          'TNT                  '
-          'BOOKSHELF            '
-          'MOSS STONE           '
-          'OBSIDIAN             '
-          'TORCH                '
-          'FIRE                 '
-          'STAIRS WOOD          '
-          'CHEST                '
-          'DIAMOND ORE          '
-          'DIAMOND BLOCK        '
-          'CRAFTING TABLE       '
-          'FARMLAND             '
-          'FURNACE INACTIVE     '
-          'FURNACE ACTIVE       '
-          'DOOR WOOD            '
-          'LADDER               '
-          'STAIRS COBBLESTONE   '
-          'DOOR IRON            '
-          'REDSTONE ORE         '
-          'SNOW                 '
-          'ICE                  '
-          'SNOW BLOCK           '
-          'CACTUS               '
-          'CLAY                 '
-          'SUGAR CANE           '
-          'FENCE                '
-          'GLOWSTONE BLOCK      '
-          'BEDROCK INVISIBLE    '
-          'STONE BRICK          '
-          'GLASS PANE           '
-          'MELON                '
-          'FENCE GATE           '
-          'GLOWING OBSIDIAN     '
-          'NETHER REACTOR CORE  ')
-      end
       object SpinEditLoopCountdown: TSpinEdit
         Left = 306
         Top = 96
@@ -200,7 +121,7 @@ object FormMain: TFormMain
         Height = 24
         MaxValue = 100000
         MinValue = 0
-        TabOrder = 1
+        TabOrder = 0
         Value = 1000
       end
       object SpinEditLoopDelay: TSpinEdit
@@ -210,7 +131,7 @@ object FormMain: TFormMain
         Height = 24
         MaxValue = 60000
         MinValue = 10
-        TabOrder = 2
+        TabOrder = 1
         Value = 500
       end
       object CheckBoxLoop: TCheckBox
@@ -221,7 +142,7 @@ object FormMain: TFormMain
         Caption = 'Run Magic Loop'
         Checked = True
         State = cbChecked
-        TabOrder = 3
+        TabOrder = 2
       end
       object CheckListBoxCommands: TCheckListBox
         Left = 0
@@ -229,14 +150,14 @@ object FormMain: TFormMain
         Width = 201
         Height = 137
         ItemHeight = 15
-        TabOrder = 4
+        TabOrder = 3
       end
       object EditMagicTest: TEdit
         Left = 376
         Top = 384
         Width = 265
         Height = 23
-        TabOrder = 5
+        TabOrder = 4
         Text = 'MAGIC _'
       end
       object ButtonTestMagic: TButton
@@ -245,7 +166,7 @@ object FormMain: TFormMain
         Width = 75
         Height = 25
         Caption = 'Test Magic'
-        TabOrder = 6
+        TabOrder = 5
         OnClick = ButtonTestMagicClick
       end
     end

--- a/UnitMain.dfm
+++ b/UnitMain.dfm
@@ -11,7 +11,6 @@ object FormMain: TFormMain
   Font.Height = -12
   Font.Name = 'Segoe UI'
   Font.Style = []
-  OldCreateOrder = True
   OnCreate = FormCreate
   PixelsPerInch = 96
   TextHeight = 15
@@ -71,14 +70,8 @@ object FormMain: TFormMain
           Font.Height = -13
           Font.Name = 'Courier New'
           Font.Style = []
+          Font.Quality = fqClearTypeNatural
           TabOrder = 0
-          CodeFolding.GutterShapeSize = 11
-          CodeFolding.CollapsedLineColor = clGrayText
-          CodeFolding.FolderBarLinesColor = clGrayText
-          CodeFolding.IndentGuidesColor = clGray
-          CodeFolding.IndentGuides = True
-          CodeFolding.ShowCollapsedLine = False
-          CodeFolding.ShowHintMark = True
           UseCodeFolding = False
           Gutter.Font.Charset = DEFAULT_CHARSET
           Gutter.Font.Color = clWindowText
@@ -92,7 +85,6 @@ object FormMain: TFormMain
             ''
             'mc.postToChat(mine_message.Value)'
             '')
-          FontSmoothing = fsmNone
         end
         object ButtonRunScript: TButton
           Left = 1
@@ -265,25 +257,12 @@ object FormMain: TFormMain
     Left = 24
     Top = 8
   end
-  object PythonEngine1: TPythonEngine
-    AutoLoad = False
-    IO = PythonGUIInputOutput1
-    Left = 272
-    Top = 8
-  end
   object PythonGUIInputOutput1: TPythonGUIInputOutput
     DelayWrites = True
     UnicodeIO = True
     RawOutput = False
     Output = Memo1
     Left = 608
-    Top = 8
-  end
-  object PythonDelphiVarMessage: TPythonDelphiVar
-    Engine = PythonEngine1
-    Module = '__main__'
-    VarName = 'mine_message'
-    Left = 448
     Top = 8
   end
   object SynPythonSyn1: TSynPythonSyn
@@ -294,56 +273,5 @@ object FormMain: TFormMain
     SystemAttri.Style = [fsBold, fsUnderline]
     Left = 520
     Top = 8
-  end
-  object PythonDelphiVarLoop: TPythonDelphiVar
-    Engine = PythonEngine1
-    Module = '__main__'
-    VarName = 'mine_loop'
-    Left = 444
-    Top = 66
-  end
-  object PythonDelphiVarLoopCountdown: TPythonDelphiVar
-    Engine = PythonEngine1
-    Module = '__main__'
-    VarName = 'mine_countdown'
-    Left = 436
-    Top = 114
-  end
-  object PythonDelphiVarLoopDelay: TPythonDelphiVar
-    Engine = PythonEngine1
-    Module = '__main__'
-    VarName = 'mine_loopdelay'
-    Left = 436
-    Top = 162
-  end
-  object PythonModule1: TPythonModule
-    Engine = PythonEngine1
-    Events = <
-      item
-        Name = 'delphi_define_commands'
-        OnExecute = PythonModule1Events0Execute
-      end
-      item
-        Name = 'delphi_request_loop_command'
-        OnExecute = PythonModule1Events1Execute
-      end
-      item
-        Name = 'delphi_request_instance'
-        OnExecute = PythonModule1Events2Execute
-      end
-      item
-        Name = 'delphi_synchronize_activities'
-        OnExecute = PythonModule1Events3Execute
-      end>
-    ModuleName = 'delphi_module'
-    Errors = <>
-    Left = 268
-    Top = 74
-  end
-  object PyDelphiWrapper1: TPyDelphiWrapper
-    Engine = PythonEngine1
-    Module = PythonModule1
-    Left = 268
-    Top = 146
   end
 end

--- a/UnitMain.dfm
+++ b/UnitMain.dfm
@@ -78,7 +78,6 @@ object FormMain: TFormMain
           Gutter.Font.Height = -11
           Gutter.Font.Name = 'Courier New'
           Gutter.Font.Style = []
-          Highlighter = SynPythonSyn1
           Lines.Strings = (
             'from mcpi.minecraft import Minecraft'
             'mc = Minecraft.create()'
@@ -250,22 +249,5 @@ object FormMain: TFormMain
         OnClick = ButtonTestMagicClick
       end
     end
-  end
-  object PythonGUIInputOutput1: TPythonGUIInputOutput
-    DelayWrites = True
-    UnicodeIO = True
-    RawOutput = False
-    Output = Memo1
-    Left = 608
-    Top = 8
-  end
-  object SynPythonSyn1: TSynPythonSyn
-    Options.AutoDetectEnabled = False
-    Options.AutoDetectLineLimit = 0
-    Options.Visible = False
-    KeyAttri.Foreground = clOlive
-    SystemAttri.Style = [fsBold, fsUnderline]
-    Left = 520
-    Top = 8
   end
 end

--- a/UnitMain.dfm
+++ b/UnitMain.dfm
@@ -251,12 +251,6 @@ object FormMain: TFormMain
       end
     end
   end
-  object ncServerSource1: TncServerSource
-    EncryptionKey = 'SetEncryptionKey'
-    OnHandleCommand = ncServerSource1HandleCommand
-    Left = 24
-    Top = 8
-  end
   object PythonGUIInputOutput1: TPythonGUIInputOutput
     DelayWrites = True
     UnicodeIO = True

--- a/UnitMain.pas
+++ b/UnitMain.pas
@@ -14,10 +14,8 @@ type
     ButtonAct: TButton;
     SynEdit1: TSynEdit;
     Memo1: TMemo;
-    PythonGUIInputOutput1: TPythonGUIInputOutput;
     ButtonRunScript: TButton;
     ComboBoxBlocks: TComboBox;
-    SynPythonSyn1: TSynPythonSyn;
     PageControl1: TPageControl;
     TabSheetCmdServer: TTabSheet;
     TabSheetScripting: TTabSheet;
@@ -90,7 +88,7 @@ procedure TFormMain.FormCreate(Sender: TObject);
 const
   SCRIPTFILE_PY = 'minescript.py';
 begin
-  MineModule.PythonEngine1.IO := Self.PythonGUIInputOutput1;
+  MineModule.PythonGUIInputOutput1.Output := Memo1;
 
   if FileExists(SCRIPTFILE_PY) then
     SynEdit1.Lines.LoadFromFile(SCRIPTFILE_PY);

--- a/UnitMain.pas
+++ b/UnitMain.pas
@@ -51,30 +51,23 @@ var
 
 implementation
 
-uses UnitCommander,  UnitMineModule;
+uses UnitMineModule;
 {$R *.dfm}
 
 procedure TFormMain.ButtonRunScriptClick(Sender: TObject);
 begin
-
-  TThread.CreateAnonymousThread(procedure
-    begin
-      MineCommander.RunMagic('hello world of minecraft!');
-    end
-  ).Start();
-
+  MineModule.StartPythonMagicThread();
 end;
 
 procedure TFormMain.ButtonTestMagicClick(Sender: TObject);
 begin
-  MineCommander.PassCommand('MAGIC', EditMagicTest.Text);
+  MineModule.PassMagicCommand(EditMagicTest.Text)
 end;
 
 procedure TFormMain.ButtonTgBotClick(Sender: TObject);
 var caption: string;
 begin
-  MineCommander.TgBotActive := not MineCommander.TgBotActive;
-  if MineCommander.TgBotActive then
+  if MineModule.BreakTgBotActivity() then
     caption := 'Stop Telegram Bot'
   else
     caption := 'Start Telegram Bot';

--- a/UnitMain.pas
+++ b/UnitMain.pas
@@ -77,18 +77,13 @@ end;
 
 procedure TFormMain.ButtonActClick(Sender: TObject);
 begin
-  with MineModule do
+  if MineModule.BreakSocketServerActivity then
   begin
-    ncServerSource1.Active := not ncServerSource1.Active;
-
-    if ncServerSource1.Active then
-    begin
-      ButtonAct.Caption := 'Stop MineServer';
-      PageControl1.ActivePageIndex := TABIX_SCRIPT;
-    end
-    else
-      ButtonAct.Caption := 'Start MineServer';
-  end;
+    ButtonAct.Caption := 'Stop MineServer';
+    PageControl1.ActivePageIndex := TABIX_SCRIPT;
+  end
+  else
+    ButtonAct.Caption := 'Start MineServer';
 end;
 
 procedure TFormMain.FormCreate(Sender: TObject);

--- a/UnitMain.pas
+++ b/UnitMain.pas
@@ -90,6 +90,8 @@ procedure TFormMain.FormCreate(Sender: TObject);
 const
   SCRIPTFILE_PY = 'minescript.py';
 begin
+  MineModule.PythonEngine1.IO := Self.PythonGUIInputOutput1;
+
   if FileExists(SCRIPTFILE_PY) then
     SynEdit1.Lines.LoadFromFile(SCRIPTFILE_PY);
 

--- a/UnitMain.pas
+++ b/UnitMain.pas
@@ -14,10 +14,10 @@ type
     ncServerSource1: TncServerSource;
     ButtonAct: TButton;
     SynEdit1: TSynEdit;
-    PythonEngine1: TPythonEngine;
+    //PythonEngine1: TPythonEngine;
     Memo1: TMemo;
     PythonGUIInputOutput1: TPythonGUIInputOutput;
-    PythonDelphiVarMessage: TPythonDelphiVar;
+    //PythonDelphiVarMessage: TPythonDelphiVar;
     ButtonRunScript: TButton;
     ComboBoxBlocks: TComboBox;
     SynPythonSyn1: TSynPythonSyn;
@@ -26,17 +26,17 @@ type
     TabSheetScripting: TTabSheet;
     Panel1: TPanel;
     TabSheetTools: TTabSheet;
-    PythonDelphiVarLoop: TPythonDelphiVar;
-    PythonDelphiVarLoopCountdown: TPythonDelphiVar;
-    PythonDelphiVarLoopDelay: TPythonDelphiVar;
+    //PythonDelphiVarLoop: TPythonDelphiVar;
+    //PythonDelphiVarLoopCountdown: TPythonDelphiVar;
+    //PythonDelphiVarLoopDelay: TPythonDelphiVar;
     SpinEditLoopCountdown: TSpinEdit;
     LabelLoopCountdown: TLabel;
     LabelLoopDelay: TLabel;
     SpinEditLoopDelay: TSpinEdit;
     CheckBoxLoop: TCheckBox;
     CheckListBoxCommands: TCheckListBox;
-    PythonModule1: TPythonModule;
-    PyDelphiWrapper1: TPyDelphiWrapper;
+    //PythonModule1: TPythonModule;
+    ///PyDelphiWrapper1: TPyDelphiWrapper;
     EditMagicTest: TEdit;
     ButtonTestMagic: TButton;
     ButtonTgBot: TButton;
@@ -46,14 +46,14 @@ type
       const aSenderComponent, aReceiverComponent: string): TArray<System.Byte>;
     procedure ButtonRunScriptClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
-    procedure PythonModule1Events0Execute(Sender: TObject; PSelf,
-      Args: PPyObject; var Result: PPyObject);
-    procedure PythonModule1Events1Execute(Sender: TObject; PSelf,
-      Args: PPyObject; var Result: PPyObject);
-    procedure PythonModule1Events2Execute(Sender: TObject; PSelf,
-      Args: PPyObject; var Result: PPyObject);
-    procedure PythonModule1Events3Execute(Sender: TObject; PSelf,
-      Args: PPyObject; var Result: PPyObject);
+//    procedure PythonModule1Events0Execute(Sender: TObject; PSelf,
+//      Args: PPyObject; var Result: PPyObject);
+//    procedure PythonModule1Events1Execute(Sender: TObject; PSelf,
+//      Args: PPyObject; var Result: PPyObject);
+//    procedure PythonModule1Events2Execute(Sender: TObject; PSelf,
+//      Args: PPyObject; var Result: PPyObject);
+//    procedure PythonModule1Events3Execute(Sender: TObject; PSelf,
+//      Args: PPyObject; var Result: PPyObject);
     procedure ButtonTestMagicClick(Sender: TObject);
     procedure ButtonTgBotClick(Sender: TObject);
   private
@@ -61,7 +61,7 @@ type
     const
       TABIX_SERVER = 0;
       TABIX_SCRIPT = 1;
-      procedure InitPython(fileini: string);
+      //procedure InitPython(fileini: string);
   public
     { Public declarations }
   end;
@@ -71,7 +71,7 @@ var
 
 implementation
 
-uses UnitCommander, IniFiles;
+uses UnitCommander,  UnitMineModule;  // IniFiles,
 {$R *.dfm}
 
 procedure TFormMain.ButtonRunScriptClick(Sender: TObject);
@@ -119,76 +119,83 @@ procedure TFormMain.FormCreate(Sender: TObject);
 const
   SCRIPTFILE_PY = 'minescript.py';
 begin
-  Self.InitPython('minecommander.ini');
+//  Self.InitPython('minecommander.ini');
 
   if FileExists(SCRIPTFILE_PY) then
     SynEdit1.Lines.LoadFromFile(SCRIPTFILE_PY);
 
-  MineCommander.RunMagic :=
-    procedure (command: String)
+  //MineCommander.RunMagic :=
+  MineModule.UpdatePySharedVariables :=
+    procedure //(command: String)
     begin
-      PythonDelphiVarMessage.Value := command;
-      PythonDelphiVarLoop.Value := CheckBoxLoop.Checked;
-      PythonDelphiVarLoopCountdown.Value := SpinEditLoopCountdown.Value;
-      PythonDelphiVarLoopDelay.Value := SpinEditLoopDelay.Value/1000;
+      with MineModule do
+      begin
+        //PythonDelphiVarMessage.Value := command;
+        PythonDelphiVarLoop.Value := CheckBoxLoop.Checked;
+        PythonDelphiVarLoopCountdown.Value := SpinEditLoopCountdown.Value;
+        PythonDelphiVarLoopDelay.Value := SpinEditLoopDelay.Value/1000;
 
-      PythonEngine1.ExecString(SynEdit1.Text);
+        PyScript := SynEdit1.Text;   //PythonEngine1.ExecString(SynEdit1.Text);
+      end;
+
     end;
 
-  MineCommander.ProcessMagic :=
-    procedure (command: String)
-    begin
-      PythonDelphiVarMessage.Value := command;
-      MineCommander.NoteWill(command);
-    end;
+//  MineCommander.ProcessMagic :=
+//    procedure (command: String)
+//    begin
+//      PythonDelphiVarMessage.Value := command;
+//      MineCommander.NoteWill(command);
+//    end;
 
-  MineCommander.RunScriptProc :=
-    procedure (script: String)
-    begin
-      PythonEngine1.ExecString(script);
-    end;
-  MineCommander.Configure(AsServer);
-  MineCommander.LoadCommands(Self.CheckListBoxCommands.Items);
+//  MineCommander.RunScriptProc :=
+//    procedure (script: String)
+//    begin
+//      PythonEngine1.ExecString(script);
+//    end;
+//  MineCommander.Configure(AsServer);
 
-  PythonModule1.Initialize();
+//  MineCommander.LoadCommands(Self.CheckListBoxCommands.Items);
+  MineModule.CommandItemsList := Self.CheckListBoxCommands.Items;
+//
+//  PythonModule1.Initialize();
   Self.SpinEditLoopCountdown.Value := 3000;
   Self.SpinEditLoopDelay.Value := 200;
 end;
 
-procedure TFormMain.InitPython(fileini: string);
-const PYSECTION = 'Python';
-var IniFile: TIniFile;
-  dllName, dllPath, pythonHome, regVersion: string;
-begin
-  var path := IncludeTrailingPathDelimiter(GetCurrentDir());
-  var iniFilename := path + fileini;
-  IniFile := TIniFile.Create(iniFilename);
-  try
-
-    dllName := IniFile.ReadString(PYSECTION, 'DllName', '');
-    if dllName > '' then
-      Self.PythonEngine1.DllName := dllName;
-
-    dllPath := IniFile.ReadString(PYSECTION, 'DllPath', '');
-    if dllPath > '' then
-      Self.PythonEngine1.DllPath := dllPath;
-
-    pythonHome := IniFile.ReadString(PYSECTION, 'Home', dllPath);
-    if pythonHome > '' then
-      Self.PythonEngine1.SetPythonHome(pythonHome);
-
-    regVersion := IniFile.ReadString(PYSECTION, 'RegVersion', '');
-    if regVersion > '' then
-    begin
-      Self.PythonEngine1.UseLastKnownVersion := False;
-      Self.PythonEngine1.RegVersion := regVersion;
-    end;
-
-    Self.PythonEngine1.LoadDll();
-  finally
-    IniFile.Free();
-  end;
-end;
+//procedure TFormMain.InitPython(fileini: string);
+//const PYSECTION = 'Python';
+//var IniFile: TIniFile;
+//  dllName, dllPath, pythonHome, regVersion: string;
+//begin
+//  var path := IncludeTrailingPathDelimiter(GetCurrentDir());
+//  var iniFilename := path + fileini;
+//  IniFile := TIniFile.Create(iniFilename);
+//  try
+//
+//    dllName := IniFile.ReadString(PYSECTION, 'DllName', '');
+//    if dllName > '' then
+//      Self.PythonEngine1.DllName := dllName;
+//
+//    dllPath := IniFile.ReadString(PYSECTION, 'DllPath', '');
+//    if dllPath > '' then
+//      Self.PythonEngine1.DllPath := dllPath;
+//
+//    pythonHome := IniFile.ReadString(PYSECTION, 'Home', dllPath);
+//    if pythonHome > '' then
+//      Self.PythonEngine1.SetPythonHome(pythonHome);
+//
+//    regVersion := IniFile.ReadString(PYSECTION, 'RegVersion', '');
+//    if regVersion > '' then
+//    begin
+//      Self.PythonEngine1.UseLastKnownVersion := False;
+//      Self.PythonEngine1.RegVersion := regVersion;
+//    end;
+//
+//    Self.PythonEngine1.LoadDll();
+//  finally
+//    IniFile.Free();
+//  end;
+//end;
 
 function TFormMain.ncServerSource1HandleCommand(Sender: TObject; aLine: TncLine;
   aCmd: Integer; const aData: TArray<System.Byte>; aRequiresResult: Boolean;
@@ -200,7 +207,7 @@ begin
 
 end;
 
-procedure TFormMain.PythonModule1Events0Execute(Sender: TObject; PSelf,
+{ procedure TFormMain.PythonModule1Events0Execute(Sender: TObject; PSelf,
   Args: PPyObject; var Result: PPyObject);
 begin
 
@@ -209,13 +216,13 @@ begin
 
   PythonEngine1.Py_INCREF(Result);
   //Result:=PythonEngine1.Py_None;
-end;
+end; }
 
-procedure TFormMain.PythonModule1Events1Execute(Sender: TObject; PSelf,
+{ procedure TFormMain.PythonModule1Events1Execute(Sender: TObject; PSelf,
   Args: PPyObject; var Result: PPyObject);
 begin
 { TODO : implement loop callback }
-  var command := MineCommander.PerformWill();
+{  var command := MineCommander.PerformWill();
   if Assigned(command) then
   begin
     var PyObj := PyDelphiWrapper1.Wrap(command.GetObject);
@@ -228,9 +235,9 @@ begin
     PythonEngine1.Py_INCREF(Result);
   end;
 
-end;
+end; }
 
-procedure TFormMain.PythonModule1Events2Execute(Sender: TObject; PSelf,
+{ procedure TFormMain.PythonModule1Events2Execute(Sender: TObject; PSelf,
   Args: PPyObject; var Result: PPyObject);
 
 begin
@@ -250,9 +257,9 @@ begin
   finally
     arglines.Free;
   end;
-end;
+end; }
 
-procedure TFormMain.PythonModule1Events3Execute(Sender: TObject; PSelf,
+{ procedure TFormMain.PythonModule1Events3Execute(Sender: TObject; PSelf,
   Args: PPyObject; var Result: PPyObject);
 begin
   var arglines := TStringList.Create();
@@ -276,6 +283,6 @@ begin
   finally
     arglines.Free;
   end;
-end;
+end; }
 
 end.

--- a/UnitMain.pas
+++ b/UnitMain.pas
@@ -140,6 +140,20 @@ begin
 
     end;
 
+  MineModule.UpdateCommandItemsListCallbackProc :=
+    procedure (cmdlist: string)
+    begin
+      var keywords := cmdlist.Split([' ']);
+      CheckListBoxCommands.CheckAll(TCheckBoxState.cbUnchecked);
+      for var keyword in keywords do
+      begin
+        var ix := CheckListBoxCommands.Items.IndexOf(keyword);
+        if ix < 0 then
+          CONTINUE;
+        CheckListBoxCommands.Checked[ix] := True;
+      end;
+    end;
+
 //  MineCommander.ProcessMagic :=
 //    procedure (command: String)
 //    begin

--- a/UnitMain.pas
+++ b/UnitMain.pas
@@ -4,14 +4,13 @@ interface
 
 uses
   System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, ncSources,
+  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls,
   Vcl.PythonGUIInputOutput, SynEdit, SynEditHighlighter,
   SynEditCodeFolding, SynHighlighterPython, Vcl.ComCtrls, Vcl.ExtCtrls,
   Vcl.Samples.Spin, Vcl.CheckLst, PythonEngine;
 
 type
   TFormMain = class(TForm)
-    ncServerSource1: TncServerSource;
     ButtonAct: TButton;
     SynEdit1: TSynEdit;
     Memo1: TMemo;
@@ -34,9 +33,6 @@ type
     ButtonTestMagic: TButton;
     ButtonTgBot: TButton;
     procedure ButtonActClick(Sender: TObject);
-    function ncServerSource1HandleCommand(Sender: TObject; aLine: TncLine;
-      aCmd: Integer; const aData: TArray<System.Byte>; aRequiresResult: Boolean;
-      const aSenderComponent, aReceiverComponent: string): TArray<System.Byte>;
     procedure ButtonRunScriptClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure ButtonTestMagicClick(Sender: TObject);
@@ -88,15 +84,18 @@ end;
 
 procedure TFormMain.ButtonActClick(Sender: TObject);
 begin
-  ncServerSource1.Active := not ncServerSource1.Active;
-
-  if ncServerSource1.Active then
+  with MineModule do
   begin
-    ButtonAct.Caption := 'Stop MineServer';
-    PageControl1.ActivePageIndex := TABIX_SCRIPT;
-  end
-  else
-    ButtonAct.Caption := 'Start MineServer';
+    ncServerSource1.Active := not ncServerSource1.Active;
+
+    if ncServerSource1.Active then
+    begin
+      ButtonAct.Caption := 'Stop MineServer';
+      PageControl1.ActivePageIndex := TABIX_SCRIPT;
+    end
+    else
+      ButtonAct.Caption := 'Start MineServer';
+  end;
 end;
 
 procedure TFormMain.FormCreate(Sender: TObject);
@@ -138,15 +137,6 @@ begin
 
   Self.SpinEditLoopCountdown.Value := 3000;
   Self.SpinEditLoopDelay.Value := 200;
-end;
-
-
-
-function TFormMain.ncServerSource1HandleCommand(Sender: TObject; aLine: TncLine;
-  aCmd: Integer; const aData: TArray<System.Byte>; aRequiresResult: Boolean;
-  const aSenderComponent, aReceiverComponent: string): TArray<System.Byte>;
-begin
-  MineCommander.ReceiveCommand(aCmd, aData);
 end;
 
 end.

--- a/UnitMain.pas
+++ b/UnitMain.pas
@@ -15,7 +15,6 @@ type
     SynEdit1: TSynEdit;
     Memo1: TMemo;
     ButtonRunScript: TButton;
-    ComboBoxBlocks: TComboBox;
     PageControl1: TPageControl;
     TabSheetCmdServer: TTabSheet;
     TabSheetScripting: TTabSheet;

--- a/UnitMain.pas
+++ b/UnitMain.pas
@@ -3,21 +3,19 @@ unit UnitMain;
 interface
 
 uses
-  Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, ncSources, PythonEngine,
-  Vcl.PythonGUIInputOutput, SynEdit, WrapDelphi, SynEditHighlighter,
+  System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
+  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, ncSources,
+  Vcl.PythonGUIInputOutput, SynEdit, SynEditHighlighter,
   SynEditCodeFolding, SynHighlighterPython, Vcl.ComCtrls, Vcl.ExtCtrls,
-  Vcl.Samples.Spin, Vcl.CheckLst;
+  Vcl.Samples.Spin, Vcl.CheckLst, PythonEngine;
 
 type
   TFormMain = class(TForm)
     ncServerSource1: TncServerSource;
     ButtonAct: TButton;
     SynEdit1: TSynEdit;
-    //PythonEngine1: TPythonEngine;
     Memo1: TMemo;
     PythonGUIInputOutput1: TPythonGUIInputOutput;
-    //PythonDelphiVarMessage: TPythonDelphiVar;
     ButtonRunScript: TButton;
     ComboBoxBlocks: TComboBox;
     SynPythonSyn1: TSynPythonSyn;
@@ -26,17 +24,12 @@ type
     TabSheetScripting: TTabSheet;
     Panel1: TPanel;
     TabSheetTools: TTabSheet;
-    //PythonDelphiVarLoop: TPythonDelphiVar;
-    //PythonDelphiVarLoopCountdown: TPythonDelphiVar;
-    //PythonDelphiVarLoopDelay: TPythonDelphiVar;
     SpinEditLoopCountdown: TSpinEdit;
     LabelLoopCountdown: TLabel;
     LabelLoopDelay: TLabel;
     SpinEditLoopDelay: TSpinEdit;
     CheckBoxLoop: TCheckBox;
     CheckListBoxCommands: TCheckListBox;
-    //PythonModule1: TPythonModule;
-    ///PyDelphiWrapper1: TPyDelphiWrapper;
     EditMagicTest: TEdit;
     ButtonTestMagic: TButton;
     ButtonTgBot: TButton;
@@ -46,14 +39,6 @@ type
       const aSenderComponent, aReceiverComponent: string): TArray<System.Byte>;
     procedure ButtonRunScriptClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
-//    procedure PythonModule1Events0Execute(Sender: TObject; PSelf,
-//      Args: PPyObject; var Result: PPyObject);
-//    procedure PythonModule1Events1Execute(Sender: TObject; PSelf,
-//      Args: PPyObject; var Result: PPyObject);
-//    procedure PythonModule1Events2Execute(Sender: TObject; PSelf,
-//      Args: PPyObject; var Result: PPyObject);
-//    procedure PythonModule1Events3Execute(Sender: TObject; PSelf,
-//      Args: PPyObject; var Result: PPyObject);
     procedure ButtonTestMagicClick(Sender: TObject);
     procedure ButtonTgBotClick(Sender: TObject);
   private
@@ -61,7 +46,6 @@ type
     const
       TABIX_SERVER = 0;
       TABIX_SCRIPT = 1;
-      //procedure InitPython(fileini: string);
   public
     { Public declarations }
   end;
@@ -71,7 +55,7 @@ var
 
 implementation
 
-uses UnitCommander,  UnitMineModule;  // IniFiles,
+uses UnitCommander,  UnitMineModule;
 {$R *.dfm}
 
 procedure TFormMain.ButtonRunScriptClick(Sender: TObject);
@@ -119,23 +103,19 @@ procedure TFormMain.FormCreate(Sender: TObject);
 const
   SCRIPTFILE_PY = 'minescript.py';
 begin
-//  Self.InitPython('minecommander.ini');
-
   if FileExists(SCRIPTFILE_PY) then
     SynEdit1.Lines.LoadFromFile(SCRIPTFILE_PY);
 
-  //MineCommander.RunMagic :=
   MineModule.UpdatePySharedVariables :=
-    procedure //(command: String)
+    procedure
     begin
       with MineModule do
       begin
-        //PythonDelphiVarMessage.Value := command;
         PythonDelphiVarLoop.Value := CheckBoxLoop.Checked;
         PythonDelphiVarLoopCountdown.Value := SpinEditLoopCountdown.Value;
         PythonDelphiVarLoopDelay.Value := SpinEditLoopDelay.Value/1000;
 
-        PyScript := SynEdit1.Text;   //PythonEngine1.ExecString(SynEdit1.Text);
+        PyScript := SynEdit1.Text;
       end;
 
     end;
@@ -154,149 +134,19 @@ begin
       end;
     end;
 
-//  MineCommander.ProcessMagic :=
-//    procedure (command: String)
-//    begin
-//      PythonDelphiVarMessage.Value := command;
-//      MineCommander.NoteWill(command);
-//    end;
-
-//  MineCommander.RunScriptProc :=
-//    procedure (script: String)
-//    begin
-//      PythonEngine1.ExecString(script);
-//    end;
-//  MineCommander.Configure(AsServer);
-
-//  MineCommander.LoadCommands(Self.CheckListBoxCommands.Items);
   MineModule.CommandItemsList := Self.CheckListBoxCommands.Items;
-//
-//  PythonModule1.Initialize();
+
   Self.SpinEditLoopCountdown.Value := 3000;
   Self.SpinEditLoopDelay.Value := 200;
 end;
 
-//procedure TFormMain.InitPython(fileini: string);
-//const PYSECTION = 'Python';
-//var IniFile: TIniFile;
-//  dllName, dllPath, pythonHome, regVersion: string;
-//begin
-//  var path := IncludeTrailingPathDelimiter(GetCurrentDir());
-//  var iniFilename := path + fileini;
-//  IniFile := TIniFile.Create(iniFilename);
-//  try
-//
-//    dllName := IniFile.ReadString(PYSECTION, 'DllName', '');
-//    if dllName > '' then
-//      Self.PythonEngine1.DllName := dllName;
-//
-//    dllPath := IniFile.ReadString(PYSECTION, 'DllPath', '');
-//    if dllPath > '' then
-//      Self.PythonEngine1.DllPath := dllPath;
-//
-//    pythonHome := IniFile.ReadString(PYSECTION, 'Home', dllPath);
-//    if pythonHome > '' then
-//      Self.PythonEngine1.SetPythonHome(pythonHome);
-//
-//    regVersion := IniFile.ReadString(PYSECTION, 'RegVersion', '');
-//    if regVersion > '' then
-//    begin
-//      Self.PythonEngine1.UseLastKnownVersion := False;
-//      Self.PythonEngine1.RegVersion := regVersion;
-//    end;
-//
-//    Self.PythonEngine1.LoadDll();
-//  finally
-//    IniFile.Free();
-//  end;
-//end;
+
 
 function TFormMain.ncServerSource1HandleCommand(Sender: TObject; aLine: TncLine;
   aCmd: Integer; const aData: TArray<System.Byte>; aRequiresResult: Boolean;
   const aSenderComponent, aReceiverComponent: string): TArray<System.Byte>;
 begin
   MineCommander.ReceiveCommand(aCmd, aData);
-
-  //ShowMessage('Command: #' + IntToStr(aCmd) + '' + command + '');
-
 end;
-
-{ procedure TFormMain.PythonModule1Events0Execute(Sender: TObject; PSelf,
-  Args: PPyObject; var Result: PPyObject);
-begin
-
-  var CmdsListStr := MineCommander.ListKeywords();
-  RESULT := PythonEngine1.EvalString(CmdsListStr);
-
-  PythonEngine1.Py_INCREF(Result);
-  //Result:=PythonEngine1.Py_None;
-end; }
-
-{ procedure TFormMain.PythonModule1Events1Execute(Sender: TObject; PSelf,
-  Args: PPyObject; var Result: PPyObject);
-begin
-{ TODO : implement loop callback }
-{  var command := MineCommander.PerformWill();
-  if Assigned(command) then
-  begin
-    var PyObj := PyDelphiWrapper1.Wrap(command.GetObject);
-    Result := PyObj;
-    //! PythonEngine1.Py_DECREF(PyObj);
-  end
-  else
-  begin
-    Result := PythonEngine1.Py_None;
-    PythonEngine1.Py_INCREF(Result);
-  end;
-
-end; }
-
-{ procedure TFormMain.PythonModule1Events2Execute(Sender: TObject; PSelf,
-  Args: PPyObject; var Result: PPyObject);
-
-begin
-  var arglines := TStringList.Create();
-  try
-    PythonEngine1.PyTupleToStrings(Args, arglines);
-    if arglines.Count > 0 then
-    begin
-      var keyword := arglines[0];
-      var instantiateScript := MineCommander.InstantiateScript(keyword);
-      if instantiateScript > '' then
-        Result := PythonEngine1.EvalString(instantiateScript)
-      else
-        Result := PythonEngine1.Py_None;
-       PythonEngine1.Py_INCREF(Result);
-    end;
-  finally
-    arglines.Free;
-  end;
-end; }
-
-{ procedure TFormMain.PythonModule1Events3Execute(Sender: TObject; PSelf,
-  Args: PPyObject; var Result: PPyObject);
-begin
-  var arglines := TStringList.Create();
-  try
-    PythonEngine1.PyTupleToStrings(Args, arglines);
-    if arglines.Count > 0 then
-    begin
-      var list := arglines[0];
-      var keywords := list.Split([' ']);
-      CheckListBoxCommands.CheckAll(TCheckBoxState.cbUnchecked);
-      for var keyword in keywords do
-      begin
-        var ix := CheckListBoxCommands.Items.IndexOf(keyword);
-        if ix < 0 then
-          CONTINUE;
-        CheckListBoxCommands.Checked[ix] := True;
-      end;
-    end;
-    Result := PythonEngine1.Py_None;
-    PythonEngine1.Py_INCREF(Result);
-  finally
-    arglines.Free;
-  end;
-end; }
 
 end.

--- a/UnitMineModule.dfm
+++ b/UnitMineModule.dfm
@@ -13,15 +13,19 @@ object MineModule: TMineModule
     Events = <
       item
         Name = 'delphi_define_commands'
+        OnExecute = PythonModule1Events0Execute
       end
       item
         Name = 'delphi_request_loop_command'
+        OnExecute = PythonModule1Events1Execute
       end
       item
         Name = 'delphi_request_instance'
+        OnExecute = PythonModule1Events2Execute
       end
       item
         Name = 'delphi_synchronize_activities'
+        OnExecute = PythonModule1Events3Execute
       end>
     ModuleName = 'delphi_module'
     Errors = <>

--- a/UnitMineModule.dfm
+++ b/UnitMineModule.dfm
@@ -5,6 +5,7 @@ object MineModule: TMineModule
   PixelsPerInch = 96
   object PythonEngine1: TPythonEngine
     AutoLoad = False
+    IO = PythonGUIInputOutput1
     Left = 32
     Top = 16
   end
@@ -70,5 +71,21 @@ object MineModule: TMineModule
     OnHandleCommand = ncServerSource1HandleCommand
     Left = 16
     Top = 312
+  end
+  object SynPythonSyn1: TSynPythonSyn
+    Options.AutoDetectEnabled = False
+    Options.AutoDetectLineLimit = 0
+    Options.Visible = False
+    KeyAttri.Foreground = clOlive
+    SystemAttri.Style = [fsBold, fsUnderline]
+    Left = 520
+    Top = 8
+  end
+  object PythonGUIInputOutput1: TPythonGUIInputOutput
+    DelayWrites = True
+    UnicodeIO = True
+    RawOutput = False
+    Left = 608
+    Top = 8
   end
 end

--- a/UnitMineModule.dfm
+++ b/UnitMineModule.dfm
@@ -1,0 +1,80 @@
+object MineModule: TMineModule
+  OnCreate = DataModuleCreate
+  Height = 360
+  Width = 802
+  PixelsPerInch = 96
+  object PythonEngine1: TPythonEngine
+    AutoLoad = False
+    Left = 32
+    Top = 16
+  end
+  object PythonModule1: TPythonModule
+    Engine = PythonEngine1
+    Events = <
+      item
+        Name = 'delphi_define_commands'
+      end
+      item
+        Name = 'delphi_request_loop_command'
+      end
+      item
+        Name = 'delphi_request_instance'
+      end
+      item
+        Name = 'delphi_synchronize_activities'
+      end>
+    ModuleName = 'delphi_module'
+    Errors = <>
+    Left = 28
+    Top = 82
+  end
+  object PyDelphiWrapper1: TPyDelphiWrapper
+    Engine = PythonEngine1
+    Left = 28
+    Top = 146
+  end
+  object PythonDelphiVarMessage: TPythonDelphiVar
+    Engine = PythonEngine1
+    Module = '__main__'
+    VarName = 'mine_message'
+    Left = 197
+    Top = 16
+  end
+  object PythonDelphiVarLoop: TPythonDelphiVar
+    Engine = PythonEngine1
+    Module = '__main__'
+    VarName = 'mine_loop'
+    Left = 189
+    Top = 82
+  end
+  object PythonDelphiVarLoopCountdown: TPythonDelphiVar
+    Engine = PythonEngine1
+    Module = '__main__'
+    VarName = 'mine_countdown'
+    Left = 188
+    Top = 154
+  end
+  object PythonDelphiVarLoopDelay: TPythonDelphiVar
+    Engine = PythonEngine1
+    Module = '__main__'
+    VarName = 'mine_loopdelay'
+    Left = 188
+    Top = 226
+  end
+  object SynPythonSyn1: TSynPythonSyn
+    Options.AutoDetectEnabled = False
+    Options.AutoDetectLineLimit = 0
+    Options.Visible = False
+    KeyAttri.Foreground = clOlive
+    SystemAttri.Style = [fsBold, fsUnderline]
+    Left = 586
+    Top = 48
+  end
+  object PythonGUIInputOutput1: TPythonGUIInputOutput
+    DelayWrites = True
+    UnicodeIO = True
+    RawOutput = False
+    Left = 594
+    Top = 144
+  end
+end

--- a/UnitMineModule.dfm
+++ b/UnitMineModule.dfm
@@ -65,20 +65,4 @@ object MineModule: TMineModule
     Left = 188
     Top = 226
   end
-  object SynPythonSyn1: TSynPythonSyn
-    Options.AutoDetectEnabled = False
-    Options.AutoDetectLineLimit = 0
-    Options.Visible = False
-    KeyAttri.Foreground = clOlive
-    SystemAttri.Style = [fsBold, fsUnderline]
-    Left = 586
-    Top = 48
-  end
-  object PythonGUIInputOutput1: TPythonGUIInputOutput
-    DelayWrites = True
-    UnicodeIO = True
-    RawOutput = False
-    Left = 594
-    Top = 144
-  end
 end

--- a/UnitMineModule.dfm
+++ b/UnitMineModule.dfm
@@ -65,4 +65,10 @@ object MineModule: TMineModule
     Left = 188
     Top = 226
   end
+  object ncServerSource1: TncServerSource
+    EncryptionKey = 'SetEncryptionKey'
+    OnHandleCommand = ncServerSource1HandleCommand
+    Left = 16
+    Top = 312
+  end
 end

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -3,7 +3,7 @@ unit UnitMineModule;
 interface
 
 uses
-  System.SysUtils, System.Classes, PythonEngine, WrapDelphi;
+  System.SysUtils, System.Classes, PythonEngine, WrapDelphi, ncSources;
 
 type
   TMineModule = class(TDataModule)
@@ -14,6 +14,7 @@ type
     PythonDelphiVarLoop: TPythonDelphiVar;
     PythonDelphiVarLoopCountdown: TPythonDelphiVar;
     PythonDelphiVarLoopDelay: TPythonDelphiVar;
+    ncServerSource1: TncServerSource;
     procedure DataModuleCreate(Sender: TObject);
     procedure PythonModule1Events0Execute(Sender: TObject; PSelf,
       Args: PPyObject; var Result: PPyObject);
@@ -23,6 +24,9 @@ type
       Args: PPyObject; var Result: PPyObject);
     procedure PythonModule1Events3Execute(Sender: TObject; PSelf,
       Args: PPyObject; var Result: PPyObject);
+    function ncServerSource1HandleCommand(Sender: TObject; aLine: TncLine;
+      aCmd: Integer; const aData: TArray<System.Byte>; aRequiresResult: Boolean;
+      const aSenderComponent, aReceiverComponent: string): TArray<System.Byte>;
 
   private
     { Private declarations }
@@ -117,6 +121,14 @@ begin
   finally
     IniFile.Free();
   end;
+end;
+
+function TMineModule.ncServerSource1HandleCommand(Sender: TObject;
+  aLine: TncLine; aCmd: Integer; const aData: TArray<System.Byte>;
+  aRequiresResult: Boolean; const aSenderComponent,
+  aReceiverComponent: string): TArray<System.Byte>;
+begin
+  MineCommander.ReceiveCommand(aCmd, aData);
 end;
 
 procedure TMineModule.PythonModule1Events0Execute(Sender: TObject; PSelf,

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -54,7 +54,7 @@ var
   MineModule: TMineModule;
 
 implementation
-uses UnitCommander, IniFiles;
+uses UnitCommander, UnitMineScripter, IniFiles;
 
 {%CLASSGROUP 'Vcl.Controls.TControl'}
 
@@ -70,6 +70,24 @@ procedure TMineModule.DataModuleCreate(Sender: TObject);
 begin
   Self.InitPython('minecommander.ini');
 
+
+  UnitMineScripter.filenameini := 'minecommander.ini';
+  var Scripter := TMineScripter.ObtainScripter(
+    procedure (script: String)
+    begin
+      PythonEngine1.ExecString(script);
+    end
+  );
+  Scripter.LoadScripts();
+
+  MineCommander.InitScriptingProc :=
+    procedure
+    begin
+      Scripter.InitScripts();
+    end;
+
+  MineCommander.Configure(AsServer);
+
   MineCommander.RunMagic :=
     procedure (command: String)
     begin
@@ -80,11 +98,6 @@ begin
       PythonEngine1.ExecString(_PyScript);
     end;
 
-  MineCommander.RunScriptProc :=
-    procedure (script: String)
-    begin
-      PythonEngine1.ExecString(script);
-    end;
 
   MineCommander.ProcessMagic :=
     procedure (command: String)
@@ -93,7 +106,7 @@ begin
       MineCommander.NoteWill(command);
     end;
 
-  MineCommander.Configure(AsServer);
+
 
   PythonModule1.Initialize();
 end;

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -18,18 +18,29 @@ type
     SynPythonSyn1: TSynPythonSyn;
     PythonGUIInputOutput1: TPythonGUIInputOutput;
     procedure DataModuleCreate(Sender: TObject);
+    procedure PythonModule1Events0Execute(Sender: TObject; PSelf,
+      Args: PPyObject; var Result: PPyObject);
+    procedure PythonModule1Events1Execute(Sender: TObject; PSelf,
+      Args: PPyObject; var Result: PPyObject);
+    procedure PythonModule1Events2Execute(Sender: TObject; PSelf,
+      Args: PPyObject; var Result: PPyObject);
+    procedure PythonModule1Events3Execute(Sender: TObject; PSelf,
+      Args: PPyObject; var Result: PPyObject);
+
   private
     { Private declarations }
 
     _UpdatePySharedVariablesProc: TProc;
+    _UpdateCommandItemsListCallbackProc: TProc<string>;
     _PyScript: string;
-    //_CommandItemsList: TStrings;
+
     procedure setCommandItemsList(CommandItemsList: TStrings);
 
     procedure InitPython(fileini: string);
   public
     { Public declarations }
     property UpdatePySharedVariables: TProc write _UpdatePySharedVariablesProc;
+    property UpdateCommandItemsListCallbackProc: TProc<string> write _UpdateCommandItemsListCallbackProc;
     property PyScript: string write _PyScript;
     property CommandItemsList: TStrings write setCommandItemsList;
   end;
@@ -109,6 +120,72 @@ begin
     Self.PythonEngine1.LoadDll();
   finally
     IniFile.Free();
+  end;
+end;
+
+procedure TMineModule.PythonModule1Events0Execute(Sender: TObject; PSelf,
+  Args: PPyObject; var Result: PPyObject);
+begin
+
+  var CmdsListStr := MineCommander.ListKeywords();
+  RESULT := PythonEngine1.EvalString(CmdsListStr);
+
+  PythonEngine1.Py_INCREF(Result);
+end;
+
+procedure TMineModule.PythonModule1Events1Execute(Sender: TObject; PSelf,
+  Args: PPyObject; var Result: PPyObject);
+begin
+  var command := MineCommander.PerformWill();
+  if Assigned(command) then
+  begin
+    var PyObj := PyDelphiWrapper1.Wrap(command.GetObject);
+    Result := PyObj;
+    //! PythonEngine1.Py_DECREF(PyObj);
+  end
+  else
+  begin
+    Result := PythonEngine1.Py_None;
+    PythonEngine1.Py_INCREF(Result);
+  end;
+end;
+
+procedure TMineModule.PythonModule1Events2Execute(Sender: TObject; PSelf,
+  Args: PPyObject; var Result: PPyObject);
+begin
+  var arglines := TStringList.Create();
+  try
+    PythonEngine1.PyTupleToStrings(Args, arglines);
+    if arglines.Count > 0 then
+    begin
+      var keyword := arglines[0];
+      var instantiateScript := MineCommander.InstantiateScript(keyword);
+      if instantiateScript > '' then
+        Result := PythonEngine1.EvalString(instantiateScript)
+      else
+        Result := PythonEngine1.Py_None;
+       PythonEngine1.Py_INCREF(Result);
+    end;
+  finally
+    arglines.Free;
+  end;
+end;
+
+procedure TMineModule.PythonModule1Events3Execute(Sender: TObject; PSelf,
+  Args: PPyObject; var Result: PPyObject);
+begin
+  var arglines := TStringList.Create();
+  try
+    PythonEngine1.PyTupleToStrings(Args, arglines);
+    if arglines.Count > 0 then
+    begin
+      var list := arglines[0];
+      _UpdateCommandItemsListCallbackProc(list);
+    end;
+    Result := PythonEngine1.Py_None;
+    PythonEngine1.Py_INCREF(Result);
+  finally
+    arglines.Free;
   end;
 end;
 

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -51,6 +51,7 @@ type
     procedure StartPythonMagicThread();
     procedure PassMagicCommand(commandline: string);
     function BreakTgBotActivity(): Boolean;
+    function BreakSocketServerActivity(): Boolean;
   end;
 
 var
@@ -62,6 +63,12 @@ uses UnitCommander, UnitMineScripter, UnitTelegrammer, IniFiles;
 var TgBot: TTelegramBot;
 
 {$R *.dfm}
+
+function TMineModule.BreakSocketServerActivity: Boolean;
+begin
+  ncServerSource1.Active := not ncServerSource1.Active;
+  RESULT := ncServerSource1.Active;
+end;
 
 function TMineModule.BreakTgBotActivity: Boolean;
 begin

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -258,6 +258,10 @@ end;
 procedure TMineModule.setCommandItemsList(CommandItemsList: TStrings);
 begin
   MineCommander.LoadCommands(CommandItemsList);
+  for var r := CommandItemsList.Count - 1 downto 0 do
+    if CommandItemsList[r].StartsWith('#') then
+      CommandItemsList.Delete(r);
+
 end;
 
 procedure TMineModule.StartPythonMagicThread;

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -3,7 +3,9 @@ unit UnitMineModule;
 interface
 
 uses
-  System.SysUtils, System.Classes, PythonEngine, WrapDelphi, ncSources;
+  System.SysUtils, System.Classes, PythonEngine, WrapDelphi, ncSources,
+  Vcl.PythonGUIInputOutput, SynEditHighlighter, SynEditCodeFolding,
+  SynHighlighterPython;
 
 type
   TMineModule = class(TDataModule)
@@ -15,6 +17,8 @@ type
     PythonDelphiVarLoopCountdown: TPythonDelphiVar;
     PythonDelphiVarLoopDelay: TPythonDelphiVar;
     ncServerSource1: TncServerSource;
+    SynPythonSyn1: TSynPythonSyn;
+    PythonGUIInputOutput1: TPythonGUIInputOutput;
     procedure DataModuleCreate(Sender: TObject);
     procedure PythonModule1Events0Execute(Sender: TObject; PSelf,
       Args: PPyObject; var Result: PPyObject);

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -44,6 +44,10 @@ type
     property UpdateCommandItemsListCallbackProc: TProc<string> write _UpdateCommandItemsListCallbackProc;
     property PyScript: string write _PyScript;
     property CommandItemsList: TStrings write setCommandItemsList;
+
+    procedure StartPythonMagicThread();
+    procedure PassMagicCommand(commandline: string);
+    function BreakTgBotActivity(): Boolean;
   end;
 
 var
@@ -55,6 +59,12 @@ uses UnitCommander, IniFiles;
 {%CLASSGROUP 'Vcl.Controls.TControl'}
 
 {$R *.dfm}
+
+function TMineModule.BreakTgBotActivity: Boolean;
+begin
+  MineCommander.TgBotActive := not MineCommander.TgBotActive;
+  RESULT := MineCommander.TgBotActive;
+end;
 
 procedure TMineModule.DataModuleCreate(Sender: TObject);
 begin
@@ -131,6 +141,11 @@ begin
   MineCommander.ReceiveCommand(aCmd, aData);
 end;
 
+procedure TMineModule.PassMagicCommand(commandline: string);
+begin
+  MineCommander.PassCommand('MAGIC', commandline);
+end;
+
 procedure TMineModule.PythonModule1Events0Execute(Sender: TObject; PSelf,
   Args: PPyObject; var Result: PPyObject);
 begin
@@ -201,6 +216,15 @@ procedure TMineModule.setCommandItemsList(CommandItemsList: TStrings);
 begin
   MineCommander.LoadCommands(CommandItemsList);
 end;
+procedure TMineModule.StartPythonMagicThread;
+begin
+  TThread.CreateAnonymousThread(procedure
+    begin
+      MineCommander.RunMagic('hello world of minecraft!');
+    end
+  ).Start();
+end;
+
 initialization
 
 finalization

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -3,8 +3,7 @@ unit UnitMineModule;
 interface
 
 uses
-  System.SysUtils, System.Classes, PythonEngine, Vcl.PythonGUIInputOutput,
-  SynEditHighlighter, SynEditCodeFolding, SynHighlighterPython, WrapDelphi;
+  System.SysUtils, System.Classes, PythonEngine, WrapDelphi;
 
 type
   TMineModule = class(TDataModule)
@@ -15,8 +14,6 @@ type
     PythonDelphiVarLoop: TPythonDelphiVar;
     PythonDelphiVarLoopCountdown: TPythonDelphiVar;
     PythonDelphiVarLoopDelay: TPythonDelphiVar;
-    SynPythonSyn1: TSynPythonSyn;
-    PythonGUIInputOutput1: TPythonGUIInputOutput;
     procedure DataModuleCreate(Sender: TObject);
     procedure PythonModule1Events0Execute(Sender: TObject; PSelf,
       Args: PPyObject; var Result: PPyObject);
@@ -83,7 +80,6 @@ begin
     end;
 
   MineCommander.Configure(AsServer);
-  //MineCommander.LoadCommands(Self.CheckListBoxCommands.Items);
 
   PythonModule1.Initialize();
 end;

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -3,8 +3,7 @@ unit UnitMineModule;
 interface
 
 uses
-  System.SysUtils, System.Classes, PythonEngine, WrapDelphi, ncSources
-  , UnitTelegrammer;
+  System.SysUtils, System.Classes, PythonEngine, WrapDelphi, ncSources;
 
 type
   TMineModule = class(TDataModule)
@@ -31,7 +30,7 @@ type
 
   private
     { Private declarations }
-    TgBot: TTelegramBot;
+
     _UpdatePySharedVariablesProc: TProc;
     _UpdateCommandItemsListCallbackProc: TProc<string>;
     _PyScript: string;
@@ -40,12 +39,9 @@ type
 
     procedure InitPython(fileini: string);
 
-    function getTgBotActive(): Boolean;
-    procedure setTgBotActive(Active: Boolean);
   public
     { Public declarations }
 
-    property TgBotActive: Boolean read getTgBotActive write setTgBotActive;
     property UpdatePySharedVariables: TProc write _UpdatePySharedVariablesProc;
     property UpdateCommandItemsListCallbackProc: TProc<string> write _UpdateCommandItemsListCallbackProc;
     property PyScript: string write _PyScript;
@@ -61,15 +57,16 @@ var
   MineModule: TMineModule;
 
 implementation
-uses UnitCommander, UnitMineScripter, IniFiles;
+uses UnitCommander, UnitMineScripter, UnitTelegrammer, IniFiles;
 {%CLASSGROUP 'Vcl.Controls.TControl'}
+var TgBot: TTelegramBot;
 
 {$R *.dfm}
 
 function TMineModule.BreakTgBotActivity: Boolean;
 begin
-  TgBotActive := not TgBotActive;
-  RESULT := TgBotActive;
+  TgBot.Active := not TgBot.Active;
+  RESULT := TgBot.Active;
 end;
 
 procedure TMineModule.DataModuleCreate(Sender: TObject);
@@ -131,11 +128,6 @@ begin
   );
 
   PythonModule1.Initialize();
-end;
-
-function TMineModule.getTgBotActive: Boolean;
-begin
-  RESULT := Self.TgBot.Active;
 end;
 
 procedure TMineModule.InitPython(fileini: string);
@@ -255,15 +247,6 @@ end;
 procedure TMineModule.setCommandItemsList(CommandItemsList: TStrings);
 begin
   MineCommander.LoadCommands(CommandItemsList);
-end;
-
-procedure TMineModule.setTgBotActive(Active: Boolean);
-begin
-  if Active <> Self.TgBot.Active then
-    if Active then
-      Self.TgBot.Run()
-    else
-      Self.TgBot.Terminate();
 end;
 
 procedure TMineModule.StartPythonMagicThread;

--- a/UnitMineModule.pas
+++ b/UnitMineModule.pas
@@ -1,0 +1,123 @@
+unit UnitMineModule;
+
+interface
+
+uses
+  System.SysUtils, System.Classes, PythonEngine, Vcl.PythonGUIInputOutput,
+  SynEditHighlighter, SynEditCodeFolding, SynHighlighterPython, WrapDelphi;
+
+type
+  TMineModule = class(TDataModule)
+    PythonEngine1: TPythonEngine;
+    PythonModule1: TPythonModule;
+    PyDelphiWrapper1: TPyDelphiWrapper;
+    PythonDelphiVarMessage: TPythonDelphiVar;
+    PythonDelphiVarLoop: TPythonDelphiVar;
+    PythonDelphiVarLoopCountdown: TPythonDelphiVar;
+    PythonDelphiVarLoopDelay: TPythonDelphiVar;
+    SynPythonSyn1: TSynPythonSyn;
+    PythonGUIInputOutput1: TPythonGUIInputOutput;
+    procedure DataModuleCreate(Sender: TObject);
+  private
+    { Private declarations }
+
+    _UpdatePySharedVariablesProc: TProc;
+    _PyScript: string;
+    //_CommandItemsList: TStrings;
+    procedure setCommandItemsList(CommandItemsList: TStrings);
+
+    procedure InitPython(fileini: string);
+  public
+    { Public declarations }
+    property UpdatePySharedVariables: TProc write _UpdatePySharedVariablesProc;
+    property PyScript: string write _PyScript;
+    property CommandItemsList: TStrings write setCommandItemsList;
+  end;
+
+var
+  MineModule: TMineModule;
+
+implementation
+uses UnitCommander, IniFiles;
+
+{%CLASSGROUP 'Vcl.Controls.TControl'}
+
+{$R *.dfm}
+
+procedure TMineModule.DataModuleCreate(Sender: TObject);
+begin
+  Self.InitPython('minecommander.ini');
+
+  MineCommander.RunMagic :=
+    procedure (command: String)
+    begin
+      if Assigned(_UpdatePySharedVariablesProc) then
+        _UpdatePySharedVariablesProc();
+      Self.PythonDelphiVarMessage.Value := command;
+
+      PythonEngine1.ExecString(_PyScript);
+    end;
+
+  MineCommander.RunScriptProc :=
+    procedure (script: String)
+    begin
+      PythonEngine1.ExecString(script);
+    end;
+
+  MineCommander.ProcessMagic :=
+    procedure (command: String)
+    begin
+      PythonDelphiVarMessage.Value := command;
+      MineCommander.NoteWill(command);
+    end;
+
+  MineCommander.Configure(AsServer);
+  //MineCommander.LoadCommands(Self.CheckListBoxCommands.Items);
+
+  PythonModule1.Initialize();
+end;
+
+procedure TMineModule.InitPython(fileini: string);
+const PYSECTION = 'Python';
+var IniFile: TIniFile;
+  dllName, dllPath, pythonHome, regVersion: string;
+begin
+  var path := IncludeTrailingPathDelimiter(GetCurrentDir());
+  var iniFilename := path + fileini;
+  IniFile := TIniFile.Create(iniFilename);
+  try
+
+    dllName := IniFile.ReadString(PYSECTION, 'DllName', '');
+    if dllName > '' then
+      Self.PythonEngine1.DllName := dllName;
+
+    dllPath := IniFile.ReadString(PYSECTION, 'DllPath', '');
+    if dllPath > '' then
+      Self.PythonEngine1.DllPath := dllPath;
+
+    pythonHome := IniFile.ReadString(PYSECTION, 'Home', dllPath);
+    if pythonHome > '' then
+      Self.PythonEngine1.SetPythonHome(pythonHome);
+
+    regVersion := IniFile.ReadString(PYSECTION, 'RegVersion', '');
+    if regVersion > '' then
+    begin
+      Self.PythonEngine1.UseLastKnownVersion := False;
+      Self.PythonEngine1.RegVersion := regVersion;
+    end;
+
+    Self.PythonEngine1.LoadDll();
+  finally
+    IniFile.Free();
+  end;
+end;
+
+procedure TMineModule.setCommandItemsList(CommandItemsList: TStrings);
+begin
+  MineCommander.LoadCommands(CommandItemsList);
+end;
+initialization
+
+finalization
+
+end.

--- a/UnitMineScripter.pas
+++ b/UnitMineScripter.pas
@@ -62,6 +62,9 @@ begin
     ini.ReadSectionValues('SCRIPTS', Self._ScriptsList);
     for var  k:= 0 to Self._ScriptsList.Count - 1 do
     begin
+      if Self._ScriptsList[k].StartsWith('#') then
+        CONTINUE;
+
       var scriptkey := Self._ScriptsList.KeyNames[k];
       var scriptpy := Self._ScriptsList.Values[scriptkey];
 

--- a/UnitTelegrammer.pas
+++ b/UnitTelegrammer.pas
@@ -29,9 +29,10 @@ type
     procedure ReplyMessage(ChatId: Integer; text: string);
   private
     _Thread: TThread;
-    function isActive(): Boolean;
+    function getActivity(): Boolean;
+    procedure setActivity(live: Boolean);
   public
-    property Active: Boolean read IsActive;
+    property Active: Boolean read getActivity write setActivity;
   private
     function DownloadMessageFile(fileId: string): string;
     procedure ProcessMessageVoice(TgMsg: TftMessage);
@@ -104,7 +105,7 @@ begin
   RESULT := Bot;
 end;
 
-function TTelegramBot.isActive: Boolean;
+function TTelegramBot.getActivity: Boolean;
 begin
   RESULT := Assigned(_Thread);
 end;
@@ -181,6 +182,15 @@ begin
 end;
 
 
+
+procedure TTelegramBot.setActivity(live: Boolean);
+begin
+  if live <> Self.Active then
+    if live then
+      Self.Run()
+    else
+      Self.Terminate();
+end;
 
 procedure TTelegramBot.Terminate;
 begin

--- a/minecommander.ini
+++ b/minecommander.ini
@@ -13,6 +13,12 @@ Token=<telegram bot token>
 [SCRIPTS]
 CONTROLLER=minecontrol.py
 CLASSES=mineclasses.py
-BRIDGE=bridge.py
+#the minimal example of daemon script definition:
+DEMODAEMON=demo.py
+#uncomment the next line to try mcpi Minecraft interaction: 
+#BRIDGE=bridge.py
 [COMMANDS]
+#the minimal example of command handler definition:
+DEMO=DemoHandler()
+#uncomment the next line to try mcpi Minecraft interaction:
 BRIDGE=BridgeHandler()

--- a/pyscripts/bridge.py
+++ b/pyscripts/bridge.py
@@ -1,5 +1,6 @@
 from mineclasses import *
 from minecontrol import *
+from minecraftcontroller import *
 import mcpi.block as block
 import random
 from minematerials import block_materials

--- a/pyscripts/demo.py
+++ b/pyscripts/demo.py
@@ -1,0 +1,24 @@
+from mineclasses import *
+from minecontrol0 import MineController
+
+class MineDemo(MineDaemon):    
+    def __init__(self, mc):
+        super().__init__(mc)
+        self.mc = mc.controller()
+        print(self.mc)
+        #self.mc.postToChat("Hi! Auto Demo Active")
+    def step(self):
+            print("Do Bridge Step!")
+class DemoHandler(DaemonHandler):
+    def __init__(self):
+        self._keyword = "DEMO"
+        MineHandler.handlers[self._keyword] = self
+        pass
+    def create_daemon(self, params):
+        print(f"Create daemon with params: {params}")
+        demo_daemon = MineDemo(MineController())
+        self.update_daemon(demo_daemon, params)
+        return demo_daemon
+    def handle(self, params):
+        print("Demo handler...")
+        return super().handle(params)

--- a/pyscripts/minecontrol.py
+++ b/pyscripts/minecontrol.py
@@ -10,18 +10,5 @@ class MineController():
     def postToChat(self, message):
         print(message)
         
-from minedynamic import *
-class MinecraftController(MineController):
-    #import the minecraft.py module from the minecraft directory
-    import mcpi.minecraft as minecraft
-    #import minecraft block module
-    import mcpi.block as block    
-    #import time, so delays can be used
-    mc = minecraft.Minecraft.create()
-    dynamic = MineDynamic(mc)
-    @classmethod
-    def controller(cls):
-        return cls.mc    
-    
-#class StubController(MineController):
+
     

--- a/pyscripts/minecraftcontroller.py
+++ b/pyscripts/minecraftcontroller.py
@@ -1,0 +1,12 @@
+from minecontrol import MineController        
+from minedynamic import *
+class MinecraftController(MineController):
+    #import the minecraft.py module from the minecraft directory
+    import mcpi.minecraft as minecraft
+    #import minecraft block module
+    import mcpi.block as block    
+    mc = minecraft.Minecraft.create()
+    dynamic = MineDynamic(mc)
+    @classmethod
+    def controller(cls):
+        return cls.mc    


### PR DESCRIPTION
1. Architect refactor:

- Move non-visual components (Python4Delphi & TCP Socket Server) into MineModule backend
- Move communication responsibility from MineCommander class

2. Generalization:

- Cleanup of the Minecraft references from GUI and default configuration  
- Add simplest common daemon demo